### PR TITLE
Update minimal number of cores in setup.ps1

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -102,7 +102,7 @@ while ($stop -ne 1){
             write-host "$cores of $maxcores cores in use."
             $available_quota = $quota.limit - $quota.currentvalue
         }
-    if (($available_quota -lt 8) -or ($skuOK -eq 0))
+    if (($available_quota -lt 4) -or ($skuOK -eq 0))
     {
         Write-Host "$Region has insufficient capacity."
         $tried_regions.Add($Region)


### PR DESCRIPTION
setup.ps1 script requires 8 cores available for Edsv4 machine, which has low availability. The same situation occurred in:
https://github.com/MicrosoftLearning/dp-203-azure-data-engineer/commit/20493dd2d8311d3172fbe07193f15d8b15556835

# Module: mslearn-databricks
## Lab/Demo: Explore Azure Databricks

Fixes # .

Changes proposed in this pull request:

- Change minimal required number of cores from 8 to 4