### PR TITLE
Update Unity Catalog exercises: Use "Azure Databricks" for product references

### DIFF
--- a/Instructions/Exercises/UC-01-Populate-metastore.md
+++ b/Instructions/Exercises/UC-01-Populate-metastore.md
@@ -69,7 +69,7 @@ If the script fails due to insufficient quota or permissions, you can try to [cr
    - **default** - A default schema for organizing data objects
    - **information_schema** - A system schema containing metadata
 
-5. Click the **Details** button in the catalog details panel and observe the **Storage location** and **Type** fields. The type **MANAGED_CATALOG** indicates that Databricks automatically manages the storage and lifecycle of data assets within this catalog.
+5. Click the **Details** button in the catalog details panel and observe the **Storage location** and **Type** fields. The type **MANAGED_CATALOG** indicates that Azure Databricks automatically manages the storage and lifecycle of data assets within this catalog.
 
 ## Create a new catalog
 


### PR DESCRIPTION
## Description

This PR updates Unity Catalog exercise files to consistently use "Azure Databricks" when referring to the product/service, rather than just "Databricks".

## Changes Made

### UC-01-Populate-metastore.md
- **Line 72**: Changed "Databricks automatically manages" to "Azure Databricks automatically manages" when describing the MANAGED_CATALOG functionality

## Analysis Summary

Reviewed three Unity Catalog exercise files using the regex pattern `(?<!azure[- ])databricks` to identify instances where "databricks" appears without "azure" or "azure-" preceding it.

**Total instances found**: 23
**Instances changed**: 1
**False positives excluded**: 22

### False Positives (Not Changed)
The following were correctly excluded as they are technical references that should remain unchanged:
- Repository/path names: `mslearn-databricks`
- Documentation URLs: `learn.microsoft.com/azure/databricks/...`
- Resource naming patterns: `databricks-*xxxxxxx*`
- Product names in official documentation: "Databricks Runtime", "Databricks SQL", "Databricks SDK"

### Files Already Correct
- **UC-01** and **UC-02**: Already correctly use "Azure Databricks documentation"
- **UC-03**: All instances are technical references (URLs, paths)

## Testing
- Verified the change maintains proper context and readability
- Confirmed all other "Databricks" references are appropriate (URLs, technical names, resource identifiers)

## Related
- Exercise pages:
  - UC-01: https://microsoftlearning.github.io/mslearn-databricks/Instructions/Exercises/UC-01-Populate-metastore.html
  - UC-02: https://microsoftlearning.github.io/mslearn-databricks/Instructions/Exercises/UC-02-Upgrade-tables-to-unity-catalog.html
  - UC-03: https://microsoftlearning.github.io/mslearn-databricks/Instructions/Exercises/UC-03-Secure.html